### PR TITLE
Fixes #15: config2vmess:  Parsing the correct address and port from config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+pnpm-lock.yaml

--- a/config-examples/vmess.json
+++ b/config-examples/vmess.json
@@ -1,0 +1,110 @@
+{
+  "policy": {
+    "system": {
+      "statsInboundUplink": true,
+      "statsInboundDownlink": true
+    }
+  },
+  "log": {
+    "access": "",
+    "error": "",
+    "loglevel": "debug"
+  },
+  "inbounds": [
+    {
+      "tag": "proxy",
+      "port": 10800,
+      "listen": "0.0.0.0",
+      "protocol": "socks",
+      "sniffing": {
+        "enabled": true,
+        "destOverride": [
+          "http",
+          "tls"
+        ]
+      },
+      "settings": {
+        "auth": "noauth",
+        "udp": true
+      }
+    }
+  ],
+  "outbounds": [
+    {
+      "tag": "proxy",
+      "protocol": "vmess",
+      "settings": {
+        "vnext": [
+          {
+            "address": "0.0.0.0",
+            "port": 12345,
+            "users": [
+              {
+                "email": "t@t.tt",
+                "encryption": "none",
+                "security": "auto",
+                "id": "73993857-9cd7-43ab-a882-bef993dce6be"
+              }
+            ]
+          }
+        ],
+        "servers": null,
+        "response": null
+      },
+      "streamSettings": {
+        "network": "tcp",
+        "security": "",
+        "tcpSettings": {
+        }
+      },
+      "mux": {
+        "enabled": false
+      }
+    },
+    {
+      "tag": "direct",
+      "protocol": "freedom",
+      "settings": {
+        "vnext": null,
+        "servers": null,
+        "response": null
+      },
+      "streamSettings": null,
+      "mux": null
+    },
+    {
+      "tag": "block",
+      "protocol": "blackhole",
+      "settings": {
+        "vnext": null,
+        "servers": null,
+        "response": {
+          "type": "http"
+        }
+      },
+      "streamSettings": null,
+      "mux": null
+    }
+  ],
+  "stats": {},
+  "api": {
+    "tag": "api",
+    "services": [
+      "StatsService"
+    ]
+  },
+  "dns": null,
+  "routing": {
+    "domainStrategy": "IPIfNonMatch",
+    "rules": [
+      {
+        "type": "field",
+        "port": null,
+        "inboundTag": "api",
+        "outboundTag": "api",
+        "ip": null,
+        "domain": null
+      }
+    ]
+  }
+}

--- a/src/config2vmess.js
+++ b/src/config2vmess.js
@@ -9,34 +9,34 @@ const VMESS_PROTO = 'vmess://';
 function streamSettingsReverse(config) {
   let net = null, tls = null, host = null, type = null, path = null;
 
-  net = config.network;
+  net = config?.network;
 
-  if (config.security === 'tls') {
+  if (config?.security === 'tls') {
     tls = 'tls';
-    if (config.tlsSettings.serverName) host = config.tlsSettings.serverName;
+    if (config?.tlsSettings?.serverName) host = config?.tlsSettings?.serverName;
   }
 
   if (net === 'kcp') {
     const { kcpSettings } = config;
-    type = kcpSettings.header.type 
+    type = kcpSettings?.header?.type
   } else if (net === 'ws') {
     const { wsSettings } = config;
-    if (host) host = wsSettings.headers.Host;
-    if (wsSettings.path) path = wsSettings.path;
+    if (host) host = wsSettings?.headers?.Host;
+    if (wsSettings?.path) path = wsSettings?.path;
   } else if (net === 'h2') {
     const { httpSettings } = config;
-    if (httpSettings.host) host = httpSettings.host.join(',');
-    path = httpSettings.path;
+    if (httpSettings?.host) host = httpSettings?.host?.join(',');
+    path = httpSettings?.path;
   } else if (net === 'quic') {
     const { quicSettings } = config;
-    host = quicSettings.security 
-    path = quicSettings.key
-    type = quicSettings.header.type;
+    host = quicSettings?.security
+    path = quicSettings?.key
+    type = quicSettings?.header?.type;
   } else if (net === 'tcp') {
     const { tcpSettings } = config;
     if (tcpSettings && tcpSettings.header && tcpSettings.header.type === 'http') {
       type = tcpSettings.header.type;
-      host = tcpSettings.header.request.headers.Host 
+      host = tcpSettings.header.request.headers.Host
       path = tcpSettings.header.request.path[0]
     }
   }
@@ -48,23 +48,24 @@ function streamSettingsReverse(config) {
 
 // the final Vmess configuration object that will be converted to JSON then to Base64
 function createVmessObj(outboundConfig) {
-  const tag = outboundConfig.tag.split(' ');
-  const port = tag.pop();
-  const add = tag.pop();
-  const ps = tag.join(" ");
-  const streamSettings = outboundConfig.streamSettings;
-  const [vnext] = outboundConfig.settings.vnext;
-  const [user] = vnext.users;
-  const id = user.id;
-  const aid = user.alterId;
+  let { tag } = outboundConfig;
+  if(tag && tag.length) {
+    tag = tag.split(" ")[0];
+  }
+  const streamSettings = outboundConfig?.streamSettings;
+  const [vnext] = outboundConfig.settings?.vnext;
+  const { address, port } = vnext;
+  const [user] = vnext?.users;
+  const id = user?.id;
+  const aid = user?.alterId;
   const { net, tls, host, type, path } = streamSettingsReverse(streamSettings);
 
   // the reason for casting out "none" here is that v2ray configs are strict
   // an empty string "" instead of "none" will break the config 
   const obj = {
     v: "2",
-    ps: ps || "none",
-    add: add || "none",
+    ps: tag || "none",
+    add: address || "none",
     port: Number(port) || 0,
     id: id || 0,
     aid: aid || 0,


### PR DESCRIPTION
Fixes #15, #13

the command `config2vmess` was previously reading the `address` and `port` from the `tag` property in the outbound item object, which was resulting into the error mentioned in the linked issue. it is now parsing the correct data from the `vnext` item object, which contains the actual data for the `address` and `port`.

Additionaly this PR also  included an example config.json for a correct vmess config file for testing purposes. located in `config-examples` folder

**Changes:**
- parse correct address and port from config file
- added null check operator for object props (`obj?.prop`) to remove the `cannot read prop of undefined` errors
- added new vmess config.json for a correct example 
- added `pnpm-lock.json` to gitignore, because there's an already existing lock file for npm.